### PR TITLE
Fix missing requests_html requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiofiles
 aiohttp
 requests
+requests-html


### PR DESCRIPTION
The newly added `requests_html` package didn't make it into the requirements.txt. Quick fix.

Before:
```
mangasee123-downloader-billweiss on  master [?] via 🐍 v3.11.3 on ☁️   
❯ which python3
/opt/homebrew/bin/python3
mangasee123-downloader-billweiss on  master [?] via 🐍 v3.11.3 on ☁️   
➜ python3 --version
Python 3.11.3
mangasee123-downloader-billweiss on  master [?] via 🐍 v3.11.3 on ☁️   
➜ python3 -m venv .venv
mangasee123-downloader-billweiss on  master [?] via 🐍 v3.11.3 on ☁️   
➜ source .venv/bin/activate
mangasee123-downloader-billweiss on  master [?] via 🐍 v3.11.3 (.venv) on ☁️   
➜ which python3
/Users/bv/repos/mangasee123-downloader-billweiss/.venv/bin/python3
mangasee123-downloader-billweiss on  master [?] via 🐍 v3.11.3 (.venv) on ☁️   
➜ which pip
/Users/bv/repos/mangasee123-downloader-billweiss/.venv/bin/pip
mangasee123-downloader-billweiss on  master [?] via 🐍 v3.11.3 (.venv) on ☁️   
➜ pip install -r requirements.txt  
Collecting aiofiles
  Using cached aiofiles-23.1.0-py3-none-any.whl (14 kB)
Collecting aiohttp
  Using cached aiohttp-3.8.4-cp311-cp311-macosx_11_0_arm64.whl (332 kB)
Collecting requests
  Using cached requests-2.28.2-py3-none-any.whl (62 kB)
Collecting attrs>=17.3.0
  Using cached attrs-22.2.0-py3-none-any.whl (60 kB)
Collecting charset-normalizer<4.0,>=2.0
  Using cached charset_normalizer-3.1.0-cp311-cp311-macosx_11_0_arm64.whl (121 kB)
Collecting multidict<7.0,>=4.5
  Using cached multidict-6.0.4-cp311-cp311-macosx_11_0_arm64.whl (29 kB)
Collecting async-timeout<5.0,>=4.0.0a3
  Using cached async_timeout-4.0.2-py3-none-any.whl (5.8 kB)
Collecting yarl<2.0,>=1.0
  Using cached yarl-1.8.2-cp311-cp311-macosx_11_0_arm64.whl (56 kB)
Collecting frozenlist>=1.1.1
  Using cached frozenlist-1.3.3-cp311-cp311-macosx_11_0_arm64.whl (34 kB)
Collecting aiosignal>=1.1.2
  Using cached aiosignal-1.3.1-py3-none-any.whl (7.6 kB)
Collecting idna<4,>=2.5
  Using cached idna-3.4-py3-none-any.whl (61 kB)
Collecting urllib3<1.27,>=1.21.1
  Using cached urllib3-1.26.15-py2.py3-none-any.whl (140 kB)
Collecting certifi>=2017.4.17
  Using cached certifi-2022.12.7-py3-none-any.whl (155 kB)
Installing collected packages: urllib3, multidict, idna, frozenlist, charset-normalizer, certifi, attrs, async-timeout, aiofiles, yarl, requests, aiosignal, aiohttp
Successfully installed aiofiles-23.1.0 aiohttp-3.8.4 aiosignal-1.3.1 async-timeout-4.0.2 attrs-22.2.0 certifi-2022.12.7 charset-normalizer-3.1.0 frozenlist-1.3.3 idna-3.4 multidict-6.0.4 requests-2.28.2 urllib3-1.26.15 yarl-1.8.2

[notice] A new release of pip is available: 23.0.1 -> 23.1
[notice] To update, run: pip install --upgrade pip
mangasee123-downloader-billweiss on  master [?] via 🐍 v3.11.3 (.venv) on ☁️   
➜ python3 MangaseeDL.py  
Traceback (most recent call last):
  File "/Users/bv/repos/mangasee123-downloader-billweiss/MangaseeDL.py", line 11, in <module>
    import requests_html
ModuleNotFoundError: No module named 'requests_html'
```
After:
```
mangasee123-downloader-billweiss on  fix-missing-requirement [?] via 🐍 v3.11.3 (.venv) on ☁️   
➜ python MangaseeDL.py                   
usage: MangaseeDL.py [-h] [-l LIMIT] manga_name [chapter_start] [chapter_end]
MangaseeDL.py: error: the following arguments are required: manga_name

    Usage: python mangasee123-downloader.py MANGA_NAME [CHAPTER_START [CHAPTER_END]]

    Download mangas from https://mangasee123.com/

    Note: MANGA_NAME is case insensitives. If it contains spaces, you can place hyphen ("-") instead of spaces or just put the name into quoutations.
    Note: Downloaded images will be placed into {working directory}/{manga name}/{chapter number}/{page number}

    Options:
        If nothing other than MANGA_NAME is provided, the script tries to download all chapters.
            Example: python downloader.py Vagabond

        If only CHAPTER_START is provided, only that chapter is downloaded.
            Example: $ python downloader.py one-piece 10
            will download chapter 10

        If CHAPTER_START and CHAPTER_END are both provided, the script tries to download CHAPTER_START to CHAPTER_END
            Example: $ python downloader.py Diamond-Is-Unbreakable 10 20
            will download chapter 10 through 20
```