### PR TITLE
MangaseeDL.py (manga) (chapter) should download one chapter, not all of them starting there

### DIFF
--- a/MangaseeDL.py
+++ b/MangaseeDL.py
@@ -220,7 +220,7 @@ if __name__ == "__main__":
 
     try:
         ch_start = args.chapter_start or min_chapter
-        ch_end = args.chapter_end or max_chapter
+        ch_end = args.chapter_end or args.chapter_start or max_chapter
 
         target_chapters = []
         for ch in range(ch_start, ch_end + 1):


### PR DESCRIPTION
Simple bug, surprised me while testing my other PRs :)

If you take the example in the help text, it used to:
```
➜ python3 MangaseeDL.py one-piece 10
Fetched details for One-Piece...
Fetching requested chapter details...
Downloading requested chapters...
Started downloading chapter 0010...
Started downloading chapter 0011...
Started downloading chapter 0012...
Started downloading chapter 0013...
Started downloading chapter 0014...
Started downloading chapter 0015...
Started downloading chapter 0016...
Started downloading chapter 0017...
Started downloading chapter 0018...
Started downloading chapter 0019...
Started downloading chapter 0020...
Started downloading chapter 0021...
Started downloading chapter 0022...
Started downloading chapter 0023...
Started downloading chapter 0024...
Started downloading chapter 0025...
Started downloading chapter 0026...
Started downloading chapter 0027...
Started downloading chapter 0028...
Started downloading chapter 0029...
Started downloading chapter 0030...
Started downloading chapter 0031...
Started downloading chapter 0032...
Started downloading chapter 0033...
Started downloading chapter 0034...
Started downloading chapter 0035...
Started downloading chapter 0036...
Started downloading chapter 0037...
Started downloading chapter 0038...
Started downloading chapter 0039...
[and it just keeps going, there are a lot of chapters]
```
And now:
```
➜ python3 MangaseeDL.py one-piece 10
Fetched details for One-Piece...
Fetching requested chapter details...
Downloading requested chapters...
Started downloading chapter 0010...
Finished downloading chapter 0010...
Download completed!
```

I guess this fix makes it hard to download starting at some chapter until the end. Would you prefer it works the current way? If so, I'm happy to whack together a quick doc fix instead.